### PR TITLE
Memory leaks fix

### DIFF
--- a/C/CO_AutoCorr.c
+++ b/C/CO_AutoCorr.c
@@ -201,6 +201,7 @@ int CO_f1ecac(const double y[], const int size)
         
         if ((autocorrs[i] - thresh)*(autocorrs[i+1] - thresh) < 0){
             out = i + 1;
+            free(autocorrs);
             return out;
         }
     }

--- a/C/helper_functions.c
+++ b/C/helper_functions.c
@@ -65,9 +65,13 @@ double quantile(const double y[], const int size, const double quant)
     // out of range limit?
     q = 0.5 / size;
     if (quant < q) {
-        return tmp[0]; // min value
+        value = tmp[0]; // min value
+        free(tmp);
+        return value; 
     } else if (quant > (1 - q)) {
-        return tmp[size - 1]; // max value
+        value = tmp[size - 1]; // max value
+        free(tmp);
+        return value; 
     }
     
     quant_idx = size * quant - 0.5;

--- a/wrap_Python/catch22_wrap_P3.c
+++ b/wrap_Python/catch22_wrap_P3.c
@@ -97,7 +97,8 @@ static PyObject * python_wrapper_double(PyObject * args, double (*f) (const doub
         result = f(copy, n);
     }   
 
-    //free(c_array);
+    free(c_array);
+    free(copy);
 
     // build the resulting string into a Python object.
     ret = Py_BuildValue("d", result);
@@ -173,7 +174,8 @@ static PyObject * python_wrapper_int(PyObject * args, int (*f) (const double*, c
         result = f(copy, n);
     }   
 
-    //free(c_array);
+    free(copy);
+    free(c_array);
 
     // build the resulting string into a Python object.
     ret = Py_BuildValue("n", result);


### PR DESCRIPTION
Hi, 

First of all, thanks for this great package!  

I noticed that when doing a lot of calls to `catch22.catch22_all(data)`, the memory consumption of grows. This pull request frees C arrays in `C/CO_AutoCorr.c`, `C/helper_functions.c` and `wrap_Python/catch22_wrap_P3.c`. With these changes, the memory consumption is stable. You can test this for yourself by running the following code before and after applying the changes that I am proposing. 

```
import catch22
import numpy as np
from memory_profiler import profile

@profile
def catch22_all(signal):
    catch22.catch22_all(signal)
    
for i in range(10000):
    signal = np.random.randn(1000)
    catch22_all(signal)
```
